### PR TITLE
Consolidating down the resource identifier concept into a single field

### DIFF
--- a/src/main/proto/telemetry-edge.proto
+++ b/src/main/proto/telemetry-edge.proto
@@ -15,7 +15,7 @@ message EnvoySummary {
 
     map<string, string> labels = 3;
 
-    string identifierName = 4;
+    string resourceId = 4;
 }
 
 enum AgentType {


### PR DESCRIPTION
# Resolves

SALUS-148

# What

Related to https://github.com/racker/salus-telemetry-envoy/pull/27 we are consolidating the identifier name/value concept into a `resourceId` and making it a distinct concept from the labels.

# TODO

There will be a related PR in the ambassador