### PR TITLE
Add README section for performing maven release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ mvn generate-sources
 Any regular Maven phases, like `compile`, `package`, or `install` will also work since they
 pass through the `generate-sources` phase, 
 [as seen here](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference).
+
+# Performing a release
+
+While on the latest commit of `master` ensure there are no local changes and run the following.
+
+```bash
+mvn release:clean release:prepare
+```
+
+### Notes 
+When choosing the next snapshot version, use the `X.Y-SNAPSHOT` form where Y "rounds up" from the 
+released `X.Y.Z`. For example, when releasing `0.1.1` specify `0.2-SNAPSHOT` as the next snapshot.
+You would again specifiy `0.2-SNAPSHOT` if later releasing a bug fix `0.1.2`.

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,8 @@
         <configuration>
           <!-- override default artifactId-version -->
           <tagNameFormat>@{project.version}</tagNameFormat>
+          <!-- default is 'clean verify` but 'clean install` will ensure local system has artifact -->
+          <preparationGoals>clean install</preparationGoals>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
# What

Related to https://github.com/racker/salus-telemetry-protocol/pull/7, this PR adds a README section documenting how we can perform a maven release of this artifact.

I also temporarily tweaked the release plugin config to locally install the "released" artifact so that we don't have depend on the Artifactory deploy-then-download cycle while we're working that out. 