### PR TITLE
Upgrading gRPC to align with version used in google cloud logging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
-## How to test
+# How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -10,8 +26,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-    <grpc.version>1.15.0</grpc.version>
-    <protoc.version>3.5.1-1</protoc.version>
+    <grpc.version>1.21.0</grpc.version>
+    <protoc.version>3.7.1</protoc.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-440

# What

When adding the Google cloud logging to Ambassador maven was complaining about version mismatches with grpc, since the Google cloud client uses grpc itself to communicate with their APIs.

# How

This is just a pom change to bump the versions.

## How to test

I have manually confirmed Ambassador is still able to service Envoy connections and communicate with etcd (which also uses grpc).