### PR TITLE
Upgrade grpc to align with jetcd 0.3.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
-## How to test
+# How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
-    <grpc.version>1.15.0</grpc.version>
+    <!--  grpc version needs to align with the one used by io.etcd:jetcd:0.3.0 downstream  -->
+    <grpc.version>1.17.1</grpc.version>
     <protoc.version>3.5.1-1</protoc.version>
+    <protobuf.version>3.9.0</protobuf.version>
   </properties>
 
   <scm>
@@ -35,6 +37,11 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <!-- ensure compatible builds with Java 10, where `Generated` symbol is not exported by default -->


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-474

# What

The upgrade of jetcd to 0.3.0 in downstream modules causes the following Maven dependency resolution issue:

```
[ERROR] Failed to execute goal on project salus-telemetry-resource-management: Could not resolve dependencies for project com.rackspace.salus:salus-telemetry-resource-management:jar:0.0.1-SNAPSHOT: Failed to collect dependencies for com.rackspace.salus:salus-telemetry-resource-management:jar:0.0.1-SNAPSHOT: Could not resolve version conflict among [com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-netty:jar:1.15.0 -> io.grpc:grpc-core:jar:[1.15.0,1.15.0], com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-protobuf:jar:1.15.0 -> io.grpc:grpc-core:jar:1.15.0, com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-protobuf:jar:1.15.0 -> io.grpc:grpc-protobuf-lite:jar:1.15.0 -> io.grpc:grpc-core:jar:1.15.0, com.rackspace.salus:salus-telemetry-protocol:jar:0.2-SNAPSHOT -> io.grpc:grpc-stub:jar:1.15.0 -> io.grpc:grpc-core:jar:1.15.0, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.etcd:jetcd-common:jar:0.3.0 -> io.grpc:grpc-core:jar:1.17.1, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.etcd:jetcd-resolver:jar:0.3.0 -> io.grpc:grpc-core:jar:1.17.1, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.grpc:grpc-core:jar:1.17.1, com.rackspace.salus:salus-telemetry-model:jar:0.1.0-SNAPSHOT -> com.rackspace.salus:salus-common:jar:0.1.0-SNAPSHOT -> io.etcd:jetcd-core:jar:0.3.0 -> io.grpc:grpc-grpclb:jar:1.17.1 -> io.grpc:grpc-core:jar:[1.17.1,1.17.1]] -> [Help 1]
``` 

Which boils down to a conflict of `grpc-core` versions `1.17.1` and `1.15.0`.

# How

Declare an upgraded version of grpc 1.17.1 that aligns with jetcd 0.3.0.

# How to test

Ensure downstream builds succeed