### PR TITLE
Update Envoy-Ambassador protocol for test-monitor operations

### DIFF
--- a/src/main/proto/telemetry-edge.proto
+++ b/src/main/proto/telemetry-edge.proto
@@ -6,6 +6,7 @@ service TelemetryAmbassador {
     rpc KeepAlive (KeepAliveRequest) returns (KeepAliveResponse) {}
     rpc PostLogEvent (LogEvent) returns (PostLogEventResponse) {}
     rpc PostMetric (PostedMetric) returns (PostMetricResponse) {}
+    rpc PostTestMonitorResults (TestMonitorResults) returns (PostTestMonitorResultsResponse) {}
 }
 
 message EnvoySummary {
@@ -35,6 +36,7 @@ message EnvoyInstruction {
         EnvoyInstructionInstall install = 1;
         EnvoyInstructionConfigure configure = 2;
         EnvoyInstructionRefresh refresh = 3;
+        EnvoyInstructionTestMonitor testMonitor = 4;
     }
 }
 
@@ -107,6 +109,21 @@ message NameTagValueMetric {
     map<string,string> tags = 3;
     map<string,double> fvalues = 4;
     map<string,string> svalues = 5;
+    map<string,int64> ivalues = 6;
 }
 
 message PostMetricResponse {}
+
+message EnvoyInstructionTestMonitor {
+    string correlationId = 1;
+    AgentType agentType = 2;
+    string content = 3;
+}
+
+message TestMonitorResults {
+    string correlationId = 1;
+    repeated string errors = 2;
+    repeated Metric metrics = 3;
+}
+
+message PostTestMonitorResultsResponse {}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-564

# What

Defines the protocol bits described here

https://github.com/racker/salus-docs/blob/master/proposals/test-monitor.md#event-and-instruction-structures

for the Ambassador side of the interaction.

# How

This is a copy of the change here

https://github.com/racker/salus-telemetry-envoy/pull/55/files#diff-031f38746c1cca790202a928d8359809

since we still don't have a way to share proto files between Go and Java.

# How to test

N/A within this repo