### PR TITLE
Update cloudbuild files

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -27,9 +27,9 @@ steps:
       - name: user.home
         path: /root
 
-  - id: VERIFY
+  - id: DEPLOY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['-B', 'verify', '-s', '.mvn/settings.xml']
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
     volumes:
       - name: user.home
         path: /root


### PR DESCRIPTION
# What

The GCP build was missing the "deploy" trigger, but while investigating that I realized the cloudbuild definition for deploy was missing.

# How

Added the cloudbuild-deploy definition and updated the non-deploy definition to use the latest structure.

# How to test

GCP builds

cc @shawnashlee @nicksunday 